### PR TITLE
fix: minimal pkg is published

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "version": "1.0.1-semantically-released",
     "description": "Eslint rules for testcafe, from the testcafe community",
     "main": "dist/index.js",
+    "files": [
+        "dist/**",
+        "docs/**"
+    ],
     "repository": {
         "type": "git",
         "url": "git://github.com/testcafe-community/eslint-plugin-testcafe-community"


### PR DESCRIPTION
## Fixes
Non-production-like packed package

### Rationale
Publishing usually means that the module is a minimal packed package
ready for consumer production consumption. In order to publish to the
current NPMv7 standard, either a files entry must be specified or the
use of `.npmignore` when `npm pack` is executed during the
`npm publish` command.