### PR TITLE
fix: `no-identical-titles` edge cases

### DIFF
--- a/lib/rules/no-identical-title.ts
+++ b/lib/rules/no-identical-title.ts
@@ -1,15 +1,51 @@
-import { CallExpression } from "typescript";
+import {
+    AST_NODE_TYPES,
+    CallExpression,
+    CallExpressionArgument,
+    Literal
+} from "@typescript-eslint/types/dist/ast-spec";
 import { createRule } from "../create-rule";
+
+/**
+ * Typescript type validation/conversion method
+ * @param arg variable to type check
+ * @returns arg as type Literal
+ */
+function isLiteral(arg: CallExpressionArgument): arg is Literal {
+    // from ast-spec types Expression -> LiteralExpression -> Literal, all literals have attribute 'value'
+    return arg.type === AST_NODE_TYPES.Literal;
+}
+
+/**
+ * Type safe method to extract possible test name of type string
+ * Prevents user from providing invalid arg0 to `test()` which can cause eslint to crash
+ * @param node Eslint evaluated ASTTree Node based on CallExpression[callee.name=test]
+ * @returns string of possible test name
+ */
+function getValidTestName(node: CallExpression): string {
+    if (!isLiteral(node.arguments[0])) {
+        throw new Error("Not a Literal expression.");
+    }
+    const arg0value: Literal["value"] = node.arguments[0].value;
+    if (
+        arg0value === null ||
+        Object.getPrototypeOf(arg0value) === RegExp.prototype
+    ) {
+        throw new Error(
+            "Unusable Literal value for test names (NullLiteral & RegExpLiteral)"
+        );
+    }
+    return arg0value.toString();
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-
 export default createRule({
     name: __filename,
     defaultOptions: [],
     meta: {
-        type:"problem",
+        type: "problem",
         messages: {
             noIdenticalTitles: "Don't use identical titles for your tests"
         },
@@ -20,31 +56,37 @@ export default createRule({
         },
         schema: []
     },
-    
+
     create(context) {
-        const testTitles: {[key: string]:[any]} = {};
+        const testTitles: { [key: string]: [CallExpression] } = {};
         return {
-            ["CallExpression[callee.name=test]"](node:any) {
-                const testTitle = node.arguments[0].value as string;
-                if(testTitle in testTitles) {
-                    testTitles[testTitle].push(node)
+            "CallExpression[callee.name=test]": (node: CallExpression) => {
+                let testTitle;
+                try {
+                    testTitle = getValidTestName(node);
+                } catch (e) {
+                    return;
+                }
+                if (testTitle in testTitles) {
+                    testTitles[testTitle].push(node);
                 } else {
                     testTitles[testTitle] = [node];
                 }
                 // const title = testTitles[testTitle];
                 // testTitles[testTitle] = [title, node]
-
             },
-            ["Program:exit"]() {
-                Object.keys(testTitles).forEach(testTitle => {           
-                    if(testTitles[testTitle].length > 1) {
-                      for(const testTitleNode of testTitles[testTitle]) {
-                        context.report({node: testTitleNode, messageId: "noIdenticalTitles"})
-
-                      }
+            "Program:exit": () => {
+                Object.values(testTitles).forEach((nodeList) => {
+                    if (nodeList.length > 1) {
+                        nodeList.forEach((testTitleNode) => {
+                            context.report({
+                                node: testTitleNode,
+                                messageId: "noIdenticalTitles"
+                            });
+                        });
                     }
-                })
+                });
             }
-        }
+        };
     }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,6 +1143,11 @@
                 "eslint-utils": "^2.0.0"
             },
             "dependencies": {
+                "@typescript-eslint/types": {
+                    "version": "4.9.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
+                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+                },
                 "eslint-utils": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -1160,12 +1165,19 @@
             "requires": {
                 "@typescript-eslint/types": "4.9.1",
                 "@typescript-eslint/visitor-keys": "4.9.1"
+            },
+            "dependencies": {
+                "@typescript-eslint/types": {
+                    "version": "4.9.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
+                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+                }
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
-            "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz",
+            "integrity": "sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w=="
         },
         "@typescript-eslint/typescript-estree": {
             "version": "4.9.1",
@@ -1182,6 +1194,11 @@
                 "tsutils": "^3.17.1"
             },
             "dependencies": {
+                "@typescript-eslint/types": {
+                    "version": "4.9.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
+                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+                },
                 "semver": {
                     "version": "7.3.4",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -1201,6 +1218,11 @@
                 "eslint-visitor-keys": "^2.0.0"
             },
             "dependencies": {
+                "@typescript-eslint/types": {
+                    "version": "4.9.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
+                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+                },
                 "eslint-visitor-keys": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,47 +1131,69 @@
             "dev": true
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.1.tgz",
-            "integrity": "sha512-c3k/xJqk0exLFs+cWSJxIjqLYwdHCuLWhnpnikmPQD2+NGAx9KjLYlBDcSI81EArh9FDYSL6dslAUSwILeWOxg==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.32.0.tgz",
+            "integrity": "sha512-WLoXcc+cQufxRYjTWr4kFt0DyEv6hDgSaFqYhIzQZ05cF+kXfqXdUh+//kgquPJVUBbL3oQGKQxwPbLxHRqm6A==",
             "requires": {
-                "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.9.1",
-                "@typescript-eslint/types": "4.9.1",
-                "@typescript-eslint/typescript-estree": "4.9.1",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^2.0.0"
+                "@types/json-schema": "^7.0.7",
+                "@typescript-eslint/scope-manager": "4.32.0",
+                "@typescript-eslint/types": "4.32.0",
+                "@typescript-eslint/typescript-estree": "4.32.0",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^3.0.0"
             },
             "dependencies": {
-                "@typescript-eslint/types": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
-                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+                "@types/json-schema": {
+                    "version": "7.0.9",
+                    "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+                    "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+                },
+                "eslint-scope": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^4.1.1"
+                    }
                 },
                 "eslint-utils": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
                     "requires": {
-                        "eslint-visitor-keys": "^1.1.0"
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+                },
+                "esrecurse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+                    "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+                    "requires": {
+                        "estraverse": "^5.2.0"
+                    },
+                    "dependencies": {
+                        "estraverse": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+                        }
                     }
                 }
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.9.1.tgz",
-            "integrity": "sha512-sa4L9yUfD/1sg9Kl8OxPxvpUcqxKXRjBeZxBuZSSV1v13hjfEJkn84n0An2hN8oLQ1PmEl2uA6FkI07idXeFgQ==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz",
+            "integrity": "sha512-DK+fMSHdM216C0OM/KR1lHXjP1CNtVIhJ54kQxfOE6x8UGFAjha8cXgDMBEIYS2XCYjjCtvTkjQYwL3uvGOo0w==",
             "requires": {
-                "@typescript-eslint/types": "4.9.1",
-                "@typescript-eslint/visitor-keys": "4.9.1"
-            },
-            "dependencies": {
-                "@typescript-eslint/types": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
-                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
-                }
+                "@typescript-eslint/types": "4.32.0",
+                "@typescript-eslint/visitor-keys": "4.32.0"
             }
         },
         "@typescript-eslint/types": {
@@ -1180,29 +1202,49 @@
             "integrity": "sha512-LE7Z7BAv0E2UvqzogssGf1x7GPpUalgG07nGCBYb1oK4mFsOiFC/VrSMKbZQzFJdN2JL5XYmsx7C7FX9p9ns0w=="
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.1.tgz",
-            "integrity": "sha512-bzP8vqwX6Vgmvs81bPtCkLtM/Skh36NE6unu6tsDeU/ZFoYthlTXbBmpIrvosgiDKlWTfb2ZpPELHH89aQjeQw==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.32.0.tgz",
+            "integrity": "sha512-tRYCgJ3g1UjMw1cGG8Yn1KzOzNlQ6u1h9AmEtPhb5V5a1TmiHWcRyF/Ic+91M4f43QeChyYlVTcf3DvDTZR9vw==",
             "requires": {
-                "@typescript-eslint/types": "4.9.1",
-                "@typescript-eslint/visitor-keys": "4.9.1",
-                "debug": "^4.1.1",
-                "globby": "^11.0.1",
+                "@typescript-eslint/types": "4.32.0",
+                "@typescript-eslint/visitor-keys": "4.32.0",
+                "debug": "^4.3.1",
+                "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
-                "lodash": "^4.17.15",
-                "semver": "^7.3.2",
-                "tsutils": "^3.17.1"
+                "semver": "^7.3.5",
+                "tsutils": "^3.21.0"
             },
             "dependencies": {
-                "@typescript-eslint/types": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
-                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "globby": {
+                    "version": "11.0.4",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+                    "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+                    "requires": {
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.1.1",
+                        "ignore": "^5.1.4",
+                        "merge2": "^1.3.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
                 },
                 "semver": {
-                    "version": "7.3.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -1210,23 +1252,18 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.1.tgz",
-            "integrity": "sha512-9gspzc6UqLQHd7lXQS7oWs+hrYggspv/rk6zzEMhCbYwPE/sF7oxo7GAjkS35Tdlt7wguIG+ViWCPtVZHz/ybQ==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.32.0.tgz",
+            "integrity": "sha512-e7NE0qz8W+atzv3Cy9qaQ7BTLwWsm084Z0c4nIO2l3Bp6u9WIgdqCgyPyV5oSPDMIW3b20H59OOCmVk3jw3Ptw==",
             "requires": {
-                "@typescript-eslint/types": "4.9.1",
+                "@typescript-eslint/types": "4.32.0",
                 "eslint-visitor-keys": "^2.0.0"
             },
             "dependencies": {
-                "@typescript-eslint/types": {
-                    "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
-                    "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA=="
-                },
                 "eslint-visitor-keys": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-                    "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ=="
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
                 }
             }
         },
@@ -2084,6 +2121,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -2555,6 +2593,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
             "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+            "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
@@ -2572,7 +2611,8 @@
         "eslint-visitor-keys": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+            "dev": true
         },
         "espree": {
             "version": "6.2.1",
@@ -2612,6 +2652,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
             "requires": {
                 "estraverse": "^4.1.0"
             }
@@ -3124,6 +3165,7 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
             "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+            "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -3136,7 +3178,8 @@
                 "ignore": {
                     "version": "5.1.8",
                     "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
                 }
             }
         },
@@ -4836,7 +4879,8 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash.capitalize": {
             "version": "4.2.1",
@@ -10790,9 +10834,9 @@
             "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
         },
         "tsutils": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-            "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
             "requires": {
                 "tslib": "^1.8.1"
             }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dependencies": {
         "@types/eslint": "^7.2.2",
         "@typescript-eslint/experimental-utils": "^4.0.1",
+        "@typescript-eslint/types": "^4.31.2",
         "requireindex": "^1.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     },
     "dependencies": {
         "@types/eslint": "^7.2.2",
-        "@typescript-eslint/experimental-utils": "^4.0.1",
-        "@typescript-eslint/types": "^4.31.2",
+        "@typescript-eslint/experimental-utils": "^4.32.0",
+        "@typescript-eslint/types": "^4.32.0",
         "requireindex": "^1.2.0"
     }
 }

--- a/tests/lib/rules/no-identical-title.ts
+++ b/tests/lib/rules/no-identical-title.ts
@@ -1,31 +1,36 @@
+import resolveFrom from "resolve-from";
+import { TSESLint } from "@typescript-eslint/experimental-utils";
 import rule from "../../../lib/rules/no-identical-title";
-import {RuleTester} from 'eslint';
-
-
-import resolveFrom from 'resolve-from';
-import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
-let ruleTester = new TSESLint.RuleTester({     parser: resolveFrom(require.resolve('eslint'), 'espree'), parserOptions: { ecmaVersion: 8 } });
+const ruleTester = new TSESLint.RuleTester({
+    parser: resolveFrom(require.resolve("eslint"), "espree"),
+    parserOptions: { ecmaVersion: 8 }
+});
 
-let message = 'Do not use the `.debug` action.';
-ruleTester.run("no-debug", rule, {
-    valid:[
+ruleTester.run("noIdenticalTitles", rule, {
+    valid: [
         `
         test("my test", async t => {});
         test("my other test", async t => {});
-        `
+        `,
+        // ignore undeterminable code (don't throw an error, not this rule's focus)
+        `test(/^regex_name/, async t => {});`,
+        `test(null, async t => {})`,
+        `test(getTestName("F-0001"), async t => {});`
     ],
     invalid: [
         {
-        code: `
-        test("my test", async t => {});
-        test("my test", async t => {});
-        `,
-        errors: [{messageId: "noIdenticalTitles"},{messageId: "noIdenticalTitles"}]
+            code: `
+                test("my test", async t => {});
+                test("my test", async t => {});
+            `,
+            errors: [
+                { messageId: "noIdenticalTitles" },
+                { messageId: "noIdenticalTitles" }
+            ]
         }
     ]
 });
-


### PR DESCRIPTION
## Problem
1. Edge cases could cause `eslint` to crash
    - `test(null, () => {})` - *incorrect but would cause a crash*
    - `test(/^regexLiteral/, () => {})` - *incorrect but would cause a crash*
    - `test(getTestName("T-001"), () => {})` - function to determine name, *(unconventional, but would cause a crash)*
2. Explicit `any` is used in Typescript implementation (Not recommended)

## Solution

1. This fix removes explicit `any` types since it defeats the purpose of using Typescript.  Ended up this hide some error conditions that could occur.

2. Added error handling for the edge cases
3. Added rule tests to verify the error handling prevents an `eslint` crash.
