### PR TITLE
fix: repair force resolutions, closes #28

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "test:unit": "jest --selectProjects UNIT",
         "test:e2e": "jest --selectProjects E2E --coverage=false",
         "generate-readme-table": "ts-node build/generate-readme-table.ts",
-        "preinstall": "npx npm-force-resolutions",
+        "preinstall": "npx force-resolutions",
         "prepare": "is-ci || husky install",
         "watch": "npm run test:unit -- --watch --"
     },


### PR DESCRIPTION
The underlying issue is https://github.com/rogeriochaves/npm-force-resolutions/issues/36. 

The accepted answer is to change npm-force-resolutions to force-resolutions, as this will not run when a package-lock.json is not present, covering the scenario when you install a package (like we do)