### PR TITLE
ci(deps): bump base node version to `20.x` in CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,20 +6,23 @@ on:
   pull_request:
     branches: [ master, next ]
 
+
+env:
+  BASE_NODE_VERSION: 20.x
+
+
 jobs:
   lint:
     name: Code Quality
     runs-on: ubuntu-latest
-    env:
-      node-version: 24.x
     steps:
       - name: git checkout HEAD
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Use Node.js ${{ env.node-version }}
+      - name: Use Node.js ${{ env.BASE_NODE_VERSION }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: ${{ env.node-version }}
+          node-version: ${{ env.BASE_NODE_VERSION }}
           cache: 'npm'
 
       - name: Install dependencies
@@ -63,18 +66,16 @@ jobs:
   lint-commits:
     name: Semantic commits
     runs-on: ubuntu-latest
-    env:
-      node-version: 24.x
     steps:
       - name: git checkout HEAD
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ env.node-version }}
+      - name: Use Node.js ${{ env.BASE_NODE_VERSION }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: ${{ env.node-version }}
+          node-version: ${{ env.BASE_NODE_VERSION }}
           cache: 'npm'
 
       - name: Install dependencies
@@ -93,16 +94,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-        node-version: 20.x
     steps:
       - name: git checkout HEAD
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Use Node.js ${{ env.node-version }}
+      - name: Use Node.js ${{ env.BASE_NODE_VERSION }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: ${{ env.node-version }}
+          node-version: ${{ env.BASE_NODE_VERSION }}
           cache: 'npm'
 
       - name: Install dependencies
@@ -133,10 +132,10 @@ jobs:
       - name: git checkout HEAD
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Use Node.js ${{ env.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: ${{ env.node-version }}
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Download bundle
@@ -164,7 +163,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: 16
+          node-version: ${{ env.BASE_NODE_VERSION }}
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
<!--
Thank you for providing a solution to make this project better!
Please fill in as much of the template below as you’re able.
-->

## Purpose

<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

## Rationale

<!-- How did you come to this conclusion as the solution? What was your
reasoning? What were you trying to do? -->

## How did you test?

<!-- Where are your unit tests? How did you verify this solution? -->

## How to Verify

<!-- List of steps to validate your PR -->

<!-- I prefer Test Driven Development (TDD) or BDD so ideally you have added to
the unit test suite to prove it was a problem before and now the problem is
solved -->

<!-- EXAMPLE Steps
1. Fetch this branch

   ```sh
   git remote add <fork_name> <fork_url.git>
   git fetch <fork_name>
   # start from master at base of branch
   git checkout $(git merge-base master <fork_name/branch>)
   ```

2. Grab relevant test files & pkgs

    ```sh
    git checkout <fork_name/branch> -- path/to/testfile(s)
    npm install
    ```

3. `npm test`. You will see # of tests will fail without this fix
4. Review & validate the test cases written to understand what scenarios are
   fixed.
5. Checkout the full branch to include the fix

    ```sh
    git checkout --detach <fork_name/branch>
    ```

6. Run `npm test` again. All tests will pass verifying there was no regression
   and the buggy scenarios were fixed.
-->
